### PR TITLE
Switch to using bats for testing

### DIFF
--- a/bioconductor-singlecellexperiment-scripts-post-install-tests.bats
+++ b/bioconductor-singlecellexperiment-scripts-post-install-tests.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+@test "SingleCellExperiment creation" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -f "$raw_singlecellexperiment_object" ]; then
+        skip "$use_existing_outputs $raw_singlecellexperiment_object exists and use_existing_outputs is set to 'true'"
+    fi
+    
+    run rm -f $raw_singlecellexperiment_object && singlecellexperiment-create-single-cell-experiment.R -a $test_matrix_file -c $test_annotation_file -o $raw_singlecellexperiment_object    
+    
+    [ "$status" -eq 0 ]
+    [ -f  "$raw_singlecellexperiment_object" ]
+}


### PR DESCRIPTION
This PR removes the previously present testing code and replaces it with tests implements with BATS. 

Now, variables for use in tests (output files, parameters etc) are still defined in the main script. But now they are also exported for consumption by a bats script. An additional parameter is passed allowing a test to be skipped if specified, and if its output is already present.

This also introduces the convention that bats tests will be stored in a file name predictable from the first test script. So bioconductor-singlecellexperiment-scripts-post-install-tests.sh runs tests in bioconductor-singlecellexperiment-scripts-post-install-tests.bats. 