### PR TITLE
Add random gene selection script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,42 @@ SingleCellExperiment is a base data structure for single cell analyses, in parti
 
 ## Install
 
-You can just download and use the wrappers here as we develop them. But We are intending for these scripts to be available alongside the SingleCellExperiment package in Bioconda. Prior to our finalising a version of this package and making it available through usual channels, it is available from our fork of the bioconda recipes using the commands below. Here we are assuming you have a healthy Bioconda install with the correct channels activate (see https://bioconda.github.io/index.html#set-up-channels). 
+The recommended method for script installation is via a Bioconda recipe called bioconda-singlecellexperiment-scripts. 
 
-You may need to install conda-build:
-
-```
-conda install conda-build
-```
-
-Now you should be able to install using the following command:
+With the [Bioconda channels](https://bioconda.github.io/#set-up-channels) configured the latest release version of the package can be installed via the regular conda install command:
 
 ```
-cd <directory where you do your Git clones>
-git clone git@github.com:ebi-gene-expression-group/bioconda-recipes.git
-git checkout bioconductor-singlecellexperiment-scripts
-cd bioconda-recipes/recipes/bioconductor-singlecellexperiment-scripts
-conda build .
-conda install --force --use-local bioconductor-singlecellexperiment-scripts
+conda install bioconductor-singlecellexperiment-scripts
 ```
+
+## Test installation
+
+There is a test script included:
+
+```
+bioconductor-singlecellexperiment-scripts-post-install-tests.sh
+```
+
+This downloads test data and executes all of the scripts described below.
+
+## Commands
+
+Currently available scripts are detailed below, each of which has usage instructions available via --help.
+
+### singlecellexperiment-create-single-cell-experiment.R: call SingleCellExperiment()
+
+To create a SingleCellExperiment from input files
+
+```
+singlecellexperiment-create-single-cell-experiment.R -a <test matrix file> -c <test annotation file> -o <file to store serialized SingleCellExperiment object>   
+```
+
+### scater-get-random-genes.R 
+
+This script is used to generate random subsets of feature names from a SingleCellExperiment object. It is called like:
+
+```
+singlecellexperiment-get-random-genes.R -i <input SingleCellExperiment in .rds format> -o <output file> -n <numbe of features> -s <random seed>
+```
+
+Output is a text file with one feature per line.

--- a/bioconductor-singlecellexperiment-scripts-post-install-tests.bats
+++ b/bioconductor-singlecellexperiment-scripts-post-install-tests.bats
@@ -10,3 +10,15 @@
     [ "$status" -eq 0 ]
     [ -f  "$raw_singlecellexperiment_object" ]
 }
+
+
+@test "Generate a random gene selection" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -f "$random_genes_file" ]; then
+        skip "$use_existing_outputs $random_genes_file exists and use_existing_outputs is set to 'true'"
+    fi
+
+    run rm -f $random_genes_file && singlecellexperiment-get-random-genes.R -i $raw_singlecellexperiment_object -o $random_genes_file -n $n_random_genes
+
+    [ "$status" -eq 0 ]
+    [ -f  "$random_genes_file" ]
+}

--- a/bioconductor-singlecellexperiment-scripts-post-install-tests.sh
+++ b/bioconductor-singlecellexperiment-scripts-post-install-tests.sh
@@ -69,10 +69,12 @@ fi
 ################################################################################
 
 export raw_singlecellexperiment_object="$output_dir/raw_sce.rds"
+export random_genes_file="$output_dir/random_genes.txt"
 
 ## Test parameters- would form config file in real workflow. DO NOT use these
 ## as default values without being sure what they mean.
 
+export n_random_genes=20
 
 ################################################################################
 # Test individual scripts

--- a/singlecellexperiment-get-random-genes.R
+++ b/singlecellexperiment-get-random-genes.R
@@ -1,0 +1,63 @@
+#!/usr/bin/env Rscript 
+
+# Given an R scater object, fetch a set of random genes. This needs to be random
+# but reproducible so we can use it in predictable tests
+
+# Load optparse we need to check inputs
+suppressPackageStartupMessages(require(optparse))
+
+# Load common functions
+suppressPackageStartupMessages(require(workflowscriptscommon))
+
+# parse options
+option_list = list(
+  make_option(
+    c("-i", "--input-object-file"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "File name in which a serialized R SingleCellExperiment object where object matrix found"
+  ),
+  make_option(
+    c("-o", "--output-text-file"),
+    action = "store",
+    default = NA,
+    type = 'character',
+    help = "File name in which a text file of randomly selected genes (one per line) should be stored."
+  ), 
+  make_option(
+    c("-n", "--n_features"),
+    action = "store",
+    default = NA,
+    type = 'integer',
+    help = "Number of features to randomly sample."
+  ), 
+  make_option(
+    c("-s", "--seed"),
+    action = "store",
+    default = 42,
+    type = 'integer',
+    help = "Number of features to randomly sample."
+  )
+)
+
+# Parse the arguments
+opt <- wsc_parse_args(option_list, mandatory = c('input_object_file', 'output_text_file', 'n_features'))
+
+if (! file.exists(opt$input_object_file)){
+    stop(paste('File', opt$input_object_file, "does not exist"))
+}
+
+# Read SingleCellExperiment object
+suppressPackageStartupMessages(require(scater))
+SingleCellExperiment <- readRDS(opt$input_object_file)
+
+# Set the seed to make random genes reproducible
+set.seed(opt$seed)
+
+# Select random genes
+random_genes <- sample(rownames(SingleCellExperiment), opt$n_features)
+
+# Write to file
+
+writeLines(con = opt$output_text_file, random_genes)


### PR DESCRIPTION
This PR adds the random gene selection script, which I'd initially included in bioconductor-scater-scripts. However it's not specific to that package so I've moved it to this more generic location (will adjust bioconductor-scater-scripts accordingly).

This simple package will need to be added to bioconda prior to biconductor-scater-scripts, and added as a dependency of that package. It may in future contain further generic manipulations of SingleCellExperiment objects. 